### PR TITLE
re-insert xhtml system-doctype declaration for xhtml output

### DIFF
--- a/src/resources-packaged/config/epilogue-servlet.xpl
+++ b/src/resources-packaged/config/epilogue-servlet.xpl
@@ -153,6 +153,7 @@
                                     <config>
                                         <method>xhtml</method>
                                         <public-doctype>-//W3C//DTD XHTML 1.0 Strict//EN</public-doctype>
+                                        <system-doctype>http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd</system-doctype>
                                         <encoding>utf-8</encoding>
                                         <content-type>application/xhtml+xml</content-type>
                                         <indent>true</indent>


### PR DESCRIPTION
Hi, i've prepared a simply commit to prevent org.orbeon.oxf.processor.converter.XMLConverter.readInput from complaining about a missing system doctype.
