### PR TITLE
fix xxforms:element on read-only instances

### DIFF
--- a/src/java/org/orbeon/oxf/xforms/XFormsUtils.java
+++ b/src/java/org/orbeon/oxf/xforms/XFormsUtils.java
@@ -946,9 +946,16 @@ public class XFormsUtils {
         return null;
     }
 
-    public static Node getNodeFromNodeInfoConvert(NodeInfo nodeInfo, String errorMessage) {
+    /**
+     * Return the underlying Node from the given NodeInfo, possibly converting it to a Dom4j Node. Changes to the returned Node may or may not 
+     * reflect on the original, depending on its type.
+     *
+     * @param nodeInfo      NodeInfo to process
+     * @return              Node
+     */
+    public static Node getNodeFromNodeInfoConvert(NodeInfo nodeInfo) {
         if (nodeInfo instanceof NodeWrapper)
-            return getNodeFromNodeInfo(nodeInfo, errorMessage);
+            return (Node) ((NodeWrapper) nodeInfo).getUnderlyingNode();
         else
             return TransformerUtils.tinyTreeToDom4j2((nodeInfo.getParent() instanceof DocumentInfo) ? nodeInfo.getParent() : nodeInfo);
     }

--- a/src/java/org/orbeon/oxf/xforms/action/actions/XFormsInsertAction.java
+++ b/src/java/org/orbeon/oxf/xforms/action/actions/XFormsInsertAction.java
@@ -199,7 +199,7 @@ public class XFormsInsertAction extends XFormsAction {
 
                 // "Otherwise, if the origin attribute is not given, then the origin node-set consists of the last
                 // node of the Node Set Binding node-set."
-                final Node singleSourceNode = XFormsUtils.getNodeFromNodeInfoConvert((NodeInfo) collectionToBeUpdated.get(collectionToBeUpdated.size() - 1), CANNOT_INSERT_READONLY_MESSAGE);
+                final Node singleSourceNode = XFormsUtils.getNodeFromNodeInfoConvert((NodeInfo) collectionToBeUpdated.get(collectionToBeUpdated.size() - 1));
                 // TODO: check namespace handling might be incorrect. Should use copyElementCopyParentNamespaces() instead?
                 final Node singleClonedNode = Dom4jUtils.createCopy(singleSourceNode);
 
@@ -227,7 +227,7 @@ public class XFormsInsertAction extends XFormsAction {
                         // This is the regular case covered by XForms 1.1 / XPath 1.0
 
                         // NOTE: Don't clone nodes if doClone == false
-                        final Node sourceNode = XFormsUtils.getNodeFromNodeInfoConvert((NodeInfo) currentObject, CANNOT_INSERT_READONLY_MESSAGE);
+                        final Node sourceNode = XFormsUtils.getNodeFromNodeInfoConvert((NodeInfo) currentObject);
                         final Node clonedNode = doClone ? (sourceNode instanceof Element) ? ((Element) sourceNode).createCopy() : (Node) sourceNode.clone() : sourceNode;
 
                         sourceNodes.add(sourceNode);

--- a/src/java/org/orbeon/oxf/xforms/function/xxforms/XXFormsElement.java
+++ b/src/java/org/orbeon/oxf/xforms/function/xxforms/XXFormsElement.java
@@ -14,10 +14,12 @@
 package org.orbeon.oxf.xforms.function.xxforms;
 
 import org.dom4j.Attribute;
+import org.dom4j.Document;
 import org.dom4j.Element;
 import org.dom4j.Node;
 import org.dom4j.QName;
 import org.orbeon.oxf.xforms.function.XFormsFunction;
+import org.orbeon.oxf.xforms.XFormsUtils;
 import org.orbeon.oxf.xml.dom4j.Dom4jUtils;
 import org.orbeon.saxon.dom4j.NodeWrapper;
 import org.orbeon.saxon.expr.Expression;
@@ -85,27 +87,20 @@ public class XXFormsElement extends XFormsFunction {
         } else if (item instanceof NodeInfo) {
             // Insert nodes
 
-            if (item instanceof NodeWrapper) {
-                // dom4j node
+            // Copy node before using it
+            final Node currentNode = XFormsUtils.getNodeFromNodeInfoConvert((NodeInfo) item);
+            // TODO: check namespace handling might be incorrect. Should use copyElementCopyParentNamespaces() instead?
+            final Node newNode = Dom4jUtils.createCopy(currentNode);
 
-                // Copy node before using it
-                final Node newNode; {
-                final Node currentNode = (Node) ((NodeWrapper) item).getUnderlyingNode();
-                    // TODO: check namespace handling might be incorrect. Should use copyElementCopyParentNamespaces() instead?
-                    newNode = Dom4jUtils.createCopy(currentNode);
-                }
-
-                if (newNode instanceof Attribute) {
-                    // Add attribute
-                    element.add((Attribute) newNode);
-                } else {
-                    // Append node
-                    element.content().add(newNode);
-                }
-
+            if (newNode instanceof Attribute) {
+                // Add attribute
+                element.add((Attribute) newNode);
+            } else if (newNode instanceof Document) {
+                // use the document root instead
+                element.content().add(newNode.getDocument().getRootElement());
             } else {
-                // Other type of node
-                // TODO: read and convert
+                // Append node
+                element.content().add(newNode);
             }
         }
         return hasNewText;


### PR DESCRIPTION
This patch fixes the problem that xxforms:element does not work on read-only instances, as described in http://orbeon-forms-ops-users.24843.n4.nabble.com/Orbeon-Bug-xxforms-element-and-read-only-instances-td3344609.html and tracked at http://forge.ow2.org/tracker/index.php?func=detail&aid=315895&group_id=168&atid=350207

It also removes a pointless (as always unused) parameter from getNodeFromNodeInfoConvert.
