### PR TITLE
Support arbitarily nested itemsets in minimal and compact appearance of xforms:select

### DIFF
--- a/src/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsSelect1Handler.java
+++ b/src/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsSelect1Handler.java
@@ -231,14 +231,15 @@ public class XFormsSelect1Handler extends XFormsControlLifecyleHandler {
 
                             itemset.visit(xmlReceiver, new ItemsetListener() {
 
-                                private int optgroupCount = 0;
+                                private boolean inOptgroup = false; // nesting opgroups is not allowed, avoid it
 
                                 public void startLevel(ContentHandler contentHandler, Item item) throws SAXException {}
 
                                 public void endLevel(ContentHandler contentHandler) throws SAXException {
-                                    if (optgroupCount-- > 0) {
+                                    if (inOptgroup) {
                                         // End xhtml:optgroup
                                         contentHandler.endElement(XMLConstants.XHTML_NAMESPACE_URI, "optgroup", optGroupQName);
+                                        inOptgroup = false;
                                     }
                                 }
 
@@ -249,15 +250,23 @@ public class XFormsSelect1Handler extends XFormsControlLifecyleHandler {
                                     final String value = item.getValue();
 
                                     if (value == null) {
+                                        assert item.hasChildren();
                                         final String itemClasses = getItemClasses(item, null);
                                         final AttributesImpl optGroupAttributes = getAttributes(XMLUtils.EMPTY_ATTRIBUTES, itemClasses, null);
                                         if (label != null)
                                             optGroupAttributes.addAttribute("", "label", "label", ContentHandlerHelper.CDATA, label);
+                                        
+                                        // if another optgroup is open, close it - nested optgroups are not allowed. Of course this results in an
+                                        // incorrect structure for tree-like itemsets, there is no way around that. If the user however does
+                                        // the indention himself, it will still look right
+                                        if (inOptgroup)
+                                            contentHandler.endElement(XMLConstants.XHTML_NAMESPACE_URI, "optgroup", optGroupQName);
 
                                         // Start xhtml:optgroup
                                         contentHandler.startElement(XMLConstants.XHTML_NAMESPACE_URI, "optgroup", optGroupQName, optGroupAttributes);
-                                        optgroupCount++;
+                                        inOptgroup = true;
                                     } else {
+                                        assert !item.hasChildren();
                                         handleItemCompact(contentHandler, optionQName, xformsSelect1Control, isMultiple, item);
                                     }
                                 }


### PR DESCRIPTION
This patch adds support for arbitrarily nested itemsets in xforms:select when using the minimal or compact appearance. Both would produce invalid markup before. The nesting is not properly reflected in the new markup (since nesting <optgroup> tags is not allowed), but together with a calculated attribute on each option specifying the nesting depth, it is possible with this patch and some CSS to display tree-like structures in the select.
I originally posted this to the mailing list, see http://orbeon-forms-ops-users.24843.n4.nabble.com/Arbitarily-nested-itemsets-in-xforms-select-td3739858.html
