### PR TITLE
Add a new experimental "archive" mode to the URL generator

### DIFF
--- a/src/java/org/orbeon/oxf/util/Connection.java
+++ b/src/java/org/orbeon/oxf/util/Connection.java
@@ -737,4 +737,13 @@ public class Connection {
         final String stringValue = propertySet.getString(HTTP_FORWARD_COOKIES_PROPERTY, "JSESSIONID JSESSIONIDSSO");
         return org.apache.commons.lang.StringUtils.split(stringValue);
     }
+
+    /**
+     * Get request headers map
+     * @return The header map
+     */
+    public Map<String, String[]> getHeadersMap() {
+        return headersMap;
+    }
+
 }

--- a/src/java/org/orbeon/oxf/util/ConnectionResult.java
+++ b/src/java/org/orbeon/oxf/util/ConnectionResult.java
@@ -272,4 +272,14 @@ public class ConnectionResult {
             indentedLogger.log(logLevel, logType, "response has no content");
         }
     }
+
+    /**
+     * Get response headers
+     * @return the response headers
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;    
+    }
+
+
 }

--- a/src/java/org/orbeon/oxf/xml/schemas/url-generator-config.rng
+++ b/src/java/org/orbeon/oxf/xml/schemas/url-generator-config.rng
@@ -93,6 +93,7 @@
                                 <value>xml</value>
                                 <value>text</value>
                                 <value>binary</value>
+                                <value>archive</value>
                             </choice>
                         </element>
                     </optional>


### PR DESCRIPTION
This new mode produces an archive containing the HTTP request and response headers and the document in a binary format.

It can be used to archive resources on the web. 
