### PR TITLE
Syntax correction to oracle-4_6.sql

### DIFF
--- a/src/resources/apps/fr/persistence/relational/ddl/oracle-4_6.sql
+++ b/src/resources/apps/fr/persistence/relational/ddl/oracle-4_6.sql
@@ -73,6 +73,7 @@ BEGIN
         :new.xml_clob := NULL;
     END IF;
 END;
+/
 
 CREATE OR REPLACE TRIGGER orbeon_form_definition_xml
          BEFORE INSERT ON orbeon_form_definition
@@ -83,3 +84,4 @@ BEGIN
         :new.xml_clob := NULL;
     END IF;
 END;
+/


### PR DESCRIPTION
Add slashes to terminate the CREATE TRIGGER statements so that this script will run correctly in SQLPlus.
