### PR TITLE
don't reformat form submissions; fixes Issue #1956

### DIFF
--- a/src/main/scala/org/orbeon/oxf/fr/relational/crud/CreateUpdateDelete.scala
+++ b/src/main/scala/org/orbeon/oxf/fr/relational/crud/CreateUpdateDelete.scala
@@ -25,6 +25,7 @@ import org.orbeon.oxf.util.ScalaUtils._
 import org.orbeon.oxf.util.{Whitespace, XPath, StringBuilderWriter, NetUtils}
 import org.orbeon.oxf.xml._
 import org.xml.sax.InputSource
+import org.orbeon.saxon.event.SaxonOutputKeys
 import org.orbeon.saxon.om.DocumentInfo
 import org.orbeon.scaxon.SAXEvents.{Atts, StartElement}
 import org.orbeon.oxf.fr.FormRunner.{XH, XF}
@@ -81,6 +82,7 @@ object RequestReader {
             TransformerUtils.getIdentityTransformerHandler
             |!> (_.getTransformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes"))
             |!> (_.getTransformer.setOutputProperty(OutputKeys.INDENT, "no"))
+            |!> (_.getTransformer.setOutputProperty(SaxonOutputKeys.INCLUDE_CONTENT_TYPE, "no"))
             |!> (_.setResult(new StreamResult(writer)))
         )
 


### PR DESCRIPTION
Proposed fix for Issue #1956 

XML data is already formatted nicely when submitted by FR no need to reformat or normalize whitespace.
