### PR TITLE
Pass query string parameters to form preview

### DIFF
--- a/src/main/scala/org/orbeon/oxf/xforms/function/xxforms/XXFormsGetQueryString.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/function/xxforms/XXFormsGetQueryString.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2014 Orbeon, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version
+ * 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The full text of the license is available at http://www.gnu.org/copyleft/lesser.html
+ */
+package org.orbeon.oxf.xforms.function.xxforms
+
+import org.orbeon.oxf.util.NetUtils
+import org.orbeon.oxf.xforms.XFormsContainingDocument
+import org.orbeon.oxf.xforms.function.{FunctionSupport, XFormsFunction}
+import org.orbeon.saxon.expr.XPathContext
+import org.orbeon.saxon.value.StringValue
+
+class XXFormsGetQueryString extends XFormsFunction with FunctionSupport {
+
+    override def evaluateItem(xpathContext: XPathContext): StringValue = {
+        val containingDocument: XFormsContainingDocument = getContainingDocument(xpathContext)
+        if (containingDocument == null) return StringValue.makeStringValue(NetUtils.getExternalContext.getRequest.getQueryString)
+        else return StringValue.makeStringValue(buildQueryString(containingDocument.getRequestParameters))
+    }
+
+    def buildQueryString(qsMap: Map[String, List[String]]): String = {
+        qsMap flatMap {
+            case (key, values) ⇒ values map (key + '=' + _)
+        } mkString("&")
+    }
+}

--- a/src/main/scala/org/orbeon/oxf/xforms/library/XXFormsIndependentFunctions.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/library/XXFormsIndependentFunctions.scala
@@ -35,9 +35,11 @@ trait XXFormsIndependentFunctions extends OrbeonFunctionLibrary {
         Fun("get-portlet-mode", classOf[XXFormsGetPortletMode], 0, 0, STRING, ALLOWS_ONE)
 
         Fun("get-window-state", classOf[XXFormsGetWindowState], 0, 0, STRING, ALLOWS_ONE)
-    
+
         Fun("get-request-path", classOf[XXFormsGetRequestPath], 0, 0, STRING, ALLOWS_ONE)
-    
+
+        Fun("get-query-string", classOf[XXFormsGetQueryString], 0, 0, STRING, ALLOWS_ONE)
+
         Fun("get-request-header", classOf[XXFormsGetRequestHeader], 0, 1, STRING, ALLOWS_ZERO_OR_MORE,
             Arg(STRING, EXACTLY_ONE)
         )

--- a/src/resources/forms/orbeon/builder/form/model.xml
+++ b/src/resources/forms/orbeon/builder/form/model.xml
@@ -391,7 +391,7 @@
             )"
         method="post"
         replace="all"
-        resource="/fr/{bind('application-name-bind')}/{bind('form-name-bind')}/test"
+        resource="/fr/{bind('application-name-bind')}/{bind('form-name-bind')}/test?{xxf:get-query-string()}"
         xxf:target="fb-test-iframe"
         xxf:show-progress="false"
     />


### PR DESCRIPTION
Create new function xxf:get-query-string() to pass query string parameters into form preview in builder. 

see forum: https://groups.google.com/forum/#!topic/orbeon/UfpVALFIyZc
