### PR TITLE
set labelHintEditor offset twice immediately to avoid initially incorrect placement in Chrome

### DIFF
--- a/src/resources/forms/orbeon/builder/resources/cell/control-resources-editor/actions.coffee
+++ b/src/resources/forms/orbeon/builder/resources/cell/control-resources-editor/actions.coffee
@@ -67,6 +67,7 @@ Builder.resourceEditorStartEdit = () ->
     labelHintEditor().selectTextInput()
     labelHintEditor().container.show()
     labelHintEditor().container.offset(labelHintOffset)
+    labelHintEditor().container.offset(labelHintOffset)
     labelHintEditor().container.width(Builder.resourceEditorCurrentLabelHint.outerWidth())
     labelHintEditor().editControl.val(labelHintValue()).focus()
     labelHintEditor().checkbox.prop('checked', isLabelHintHtml())


### PR DESCRIPTION
Hacky fix for issue #2093 