### PR TITLE
Added AVT support to navindex attribute

### DIFF
--- a/src/main/java/org/orbeon/oxf/xforms/XFormsConstants.java
+++ b/src/main/java/org/orbeon/oxf/xforms/XFormsConstants.java
@@ -95,6 +95,7 @@ public class XFormsConstants {
 
     public static final QName CLASS_QNAME = new QName("class");
     public static final QName STYLE_QNAME = new QName("style");
+    public static final QName NAVINDEX_QNAME = new QName("navindex");
 
     public static final QName APPEARANCE_QNAME = new QName("appearance");
     public static final QName MEDIATYPE_QNAME = new QName("mediatype");

--- a/src/main/java/org/orbeon/oxf/xforms/processor/handlers/XFormsBaseHandler.java
+++ b/src/main/java/org/orbeon/oxf/xforms/processor/handlers/XFormsBaseHandler.java
@@ -104,18 +104,24 @@ public abstract class XFormsBaseHandler extends ElementHandler {
         return control == null || ! control.isRelevant();
     }
 
-    public static void handleAccessibilityAttributes(Attributes srcAttributes, AttributesImpl destAttributes) {
+    public static void handleAccessibilityAttributes(Attributes srcAttributes, AttributesImpl destAttributes, XFormsControl control) {
         // Handle "tabindex"
         {
             // This is the standard XForms attribute
             String value = srcAttributes.getValue("navindex");
-            if (value == null) {
-                // Try the the XHTML attribute
+            if(value != null) {
+                if (control != null && control.isRelevant()) {
+                    destAttributes.addAttribute("", "tabindex", "tabindex", XMLReceiverHelper.CDATA, control.evaluateAvt(value));
+                } else {
+                    destAttributes.addAttribute("", "tabindex", "tabindex", XMLReceiverHelper.CDATA, XFormsUtils.maybeAVT(value) ? "" : value);
+                }
+            } else {
+                // Try the the XHTML attribute (which doesn't have AVT support)
                 value = srcAttributes.getValue("tabindex");
+                if(value != null) {
+                	destAttributes.addAttribute("", "tabindex", "tabindex", XMLReceiverHelper.CDATA, value);
+                }
             }
-
-            if (value != null)
-                destAttributes.addAttribute("", "tabindex", "tabindex", XMLReceiverHelper.CDATA, value);
         }
         // Handle "accesskey"
         {

--- a/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsSecretHandler.java
+++ b/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsSecretHandler.java
@@ -50,7 +50,7 @@ public class XFormsSecretHandler extends XFormsControlLifecyleHandler {
                         handlerContext.isTemplate() || secretControl == null || secretControl.getExternalValue() == null ? "" : secretControl.getExternalValue());
 
                 // Handle accessibility attributes
-                handleAccessibilityAttributes(attributes, containerAttributes);
+                handleAccessibilityAttributes(attributes, containerAttributes, secretControl);
 
                 // Output all extension attributes
                 if (isConcreteControl) {

--- a/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsSelect1Handler.java
+++ b/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsSelect1Handler.java
@@ -113,7 +113,7 @@ public class XFormsSelect1Handler extends XFormsControlLifecyleHandler {
                 containerAttributes.addAttribute("", "multiple", "multiple", XMLReceiverHelper.CDATA, "multiple");
 
             // Handle accessibility attributes
-            handleAccessibilityAttributes(attributes, containerAttributes);
+            handleAccessibilityAttributes(attributes, containerAttributes, xformsControl);
 
             if (isHTMLDisabled(xformsControl))
                 outputDisabledAttribute(containerAttributes);
@@ -379,7 +379,7 @@ public class XFormsSelect1Handler extends XFormsControlLifecyleHandler {
                             reusableAttributes.addAttribute("", "checked", "checked", XMLReceiverHelper.CDATA, "checked");
 
                         if (isFirst)
-                            handleAccessibilityAttributes(attributes, reusableAttributes);
+                            handleAccessibilityAttributes(attributes, reusableAttributes, (XFormsControl) control);
                     }
 
                     if (baseHandler.isHTMLDisabled((XFormsControl) control))// cast because Java is not aware that XFormsValueControl extends XFormsControl

--- a/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsTextareaHandler.java
+++ b/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsTextareaHandler.java
@@ -50,7 +50,7 @@ public class XFormsTextareaHandler extends XFormsControlLifecyleHandler {
                 containerAttributes.addAttribute("", "name", "name", XMLReceiverHelper.CDATA, effectiveId);
 
                 // Handle accessibility attributes
-                handleAccessibilityAttributes(attributes, containerAttributes);
+                handleAccessibilityAttributes(attributes, containerAttributes, textareaControl);
 
                 // Output all extension attributes
                 if (isConcreteControl) {

--- a/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsTriggerHandler.java
+++ b/src/main/java/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsTriggerHandler.java
@@ -69,7 +69,7 @@ public abstract class XFormsTriggerHandler extends XFormsControlLifecyleHandler 
         }
 
         // Handle accessibility attributes on <a>, <input> or <button>
-        handleAccessibilityAttributes(attributes, containerAttributes);
+        handleAccessibilityAttributes(attributes, containerAttributes, control);
 
         return containerAttributes;
     }

--- a/src/main/scala/org/orbeon/oxf/xforms/analysis/ElementAnalysis.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/analysis/ElementAnalysis.scala
@@ -400,7 +400,7 @@ trait ElementRepeats {
 
 object ElementAnalysis {
 
-    val CommonExtensionAttributes = Set(STYLE_QNAME, CLASS_QNAME)
+    val CommonExtensionAttributes = Set(STYLE_QNAME, CLASS_QNAME, NAVINDEX_QNAME)
 
     val propagateBreaks = new Breaks
 

--- a/src/main/scala/org/orbeon/oxf/xforms/control/ControlExtensionAttributesSupport.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/control/ControlExtensionAttributesSupport.scala
@@ -67,7 +67,7 @@ trait ControlExtensionAttributesSupport {
     final def addExtensionAttributesExceptClassAndAcceptForHandler(attributesImpl: AttributesImpl, namespaceURI: String): Unit =
         for {
             (name, value) ← evaluatedExtensionAttributes
-            if name.getNamespaceURI == namespaceURI && ! StandardAttributesToFilterOnHandler(name)
+            if name.getNamespaceURI == namespaceURI && ! StandardAttributesToFilterOnHandler(name) && name != NAVINDEX_QNAME
             if value ne null
             localName = name.getName
         } attributesImpl.addAttribute("", localName, localName, XMLReceiverHelper.CDATA, value)

--- a/src/main/scala/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsInputHandler.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsInputHandler.scala
@@ -135,7 +135,7 @@ class XFormsInputHandler extends XFormsControlLifecyleHandler(false) with Handle
 
                     reusableAttributes.addAttribute("", "class", "class", XMLReceiverHelper.CDATA, inputClasses.toString)
 
-                    handleAccessibilityAttributes(attributes, reusableAttributes)
+                    handleAccessibilityAttributes(attributes, reusableAttributes, control)
                     if (isDateMinimal) {
                         val imgQName = XMLUtils.buildQName(xhtmlPrefix, "img")
                         reusableAttributes.addAttribute("", "src", "src", XMLReceiverHelper.CDATA, CALENDAR_IMAGE_URI)
@@ -181,7 +181,7 @@ class XFormsInputHandler extends XFormsControlLifecyleHandler(false) with Handle
 
                     // TODO: set @size and @maxlength
 
-                    handleAccessibilityAttributes(attributes, reusableAttributes)
+                    handleAccessibilityAttributes(attributes, reusableAttributes, control)
                     xmlReceiver.startElement(XHTML_NAMESPACE_URI, "input", inputQName, reusableAttributes)
                     xmlReceiver.endElement(XHTML_NAMESPACE_URI, "input", inputQName)
                 }

--- a/src/main/scala/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsOutputHandler.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsOutputHandler.scala
@@ -49,7 +49,7 @@ class XFormsOutputDefaultHandler extends XFormsControlLifecyleHandler(false) wit
         val containerAttributes = getContainerAttributes(uri, localname, attributes, effectiveId, outputControl)
 
         // Handle accessibility attributes on <span>
-        XFormsBaseHandler.handleAccessibilityAttributes(attributes, containerAttributes)
+        XFormsBaseHandler.handleAccessibilityAttributes(attributes, containerAttributes, outputControl)
 
         withElement(handlerContext.findXHTMLPrefix, XHTML_NAMESPACE_URI, getContainingElementName, containerAttributes) {
             if (isConcreteControl) {
@@ -75,7 +75,7 @@ class XFormsOutputHTMLHandler extends XFormsControlLifecyleHandler(false) with X
         val containerAttributes = getContainerAttributes(uri, localname, attributes, effectiveId, outputControl)
 
         // Handle accessibility attributes on <div>
-        XFormsBaseHandler.handleAccessibilityAttributes(attributes, containerAttributes)
+        XFormsBaseHandler.handleAccessibilityAttributes(attributes, containerAttributes, outputControl)
 
         withElement(xhtmlPrefix, XHTML_NAMESPACE_URI, getContainingElementName, containerAttributes) {
             if (isConcreteControl) {
@@ -106,7 +106,7 @@ class XFormsOutputImageHandler extends XFormsControlLifecyleHandler(false) with 
         val srcValue = XFormsOutputControl.getExternalValueOrDefault(outputControl, mediatypeValue)
         containerAttributes.addAttribute("", "src", "src", XMLReceiverHelper.CDATA, if (srcValue ne null) srcValue else XFormsConstants.DUMMY_IMAGE_URI)
 
-        XFormsBaseHandler.handleAccessibilityAttributes(attributes, containerAttributes)
+        XFormsBaseHandler.handleAccessibilityAttributes(attributes, containerAttributes, outputControl)
 
         element(xhtmlPrefix, XHTML_NAMESPACE_URI, "img", containerAttributes)
     }
@@ -180,7 +180,7 @@ class XFormsOutputDownloadHandler extends XFormsControlLifecyleHandler(false) wi
             }
 
             val aAttributes = anchorAttributes
-            XFormsBaseHandler.handleAccessibilityAttributes(attributes, aAttributes)
+            XFormsBaseHandler.handleAccessibilityAttributes(attributes, aAttributes, outputControl)
 
             withElement(xhtmlPrefix, XHTML_NAMESPACE_URI, "a", aAttributes) {
                 val labelValue             = Option(control) map (_.getLabel) orNull

--- a/src/main/scala/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsUploadHandler.scala
+++ b/src/main/scala/org/orbeon/oxf/xforms/processor/handlers/xhtml/XFormsUploadHandler.scala
@@ -63,7 +63,7 @@ class XFormsUploadHandler extends XFormsControlLifecyleHandler(false) with Handl
                 uploadControl flatMap (_.acceptValue) map mediatypeToAccept foreach
                     (accept ⇒ reusableAttributes.addAttribute("", "accept", "accept", XMLReceiverHelper.CDATA, accept))
     
-                XFormsBaseHandler.handleAccessibilityAttributes(attributes, reusableAttributes)
+                XFormsBaseHandler.handleAccessibilityAttributes(attributes, reusableAttributes, control)
                 element(xhtmlPrefix, XHTML_NAMESPACE_URI, "input", reusableAttributes)
             }
     

--- a/src/resources-packaged/ops/javascript/orbeon/xforms/server/AjaxServer.js
+++ b/src/resources-packaged/ops/javascript/orbeon/xforms/server/AjaxServer.js
@@ -1655,7 +1655,11 @@
                                     var nameAttribute = ORBEON.util.Dom.getAttribute(attributeElement, "name");
                                     var htmlElement = ORBEON.util.Dom.get(forAttribute);
                                     if (htmlElement != null) {// use case: xh:html/@lang but HTML fragment produced
-                                        ORBEON.util.Dom.setAttribute(htmlElement, nameAttribute, newAttributeValue);
+                                        if (nameAttribute == 'navindex') {
+                                            $(htmlElement).find('*[tabindex]').attr('tabindex', newAttributeValue);
+                                        } else {
+                                            ORBEON.util.Dom.setAttribute(htmlElement, nameAttribute, newAttributeValue);
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
A proposed implementation for this question because we wanted to use navindexes in repeats as well.
http://discuss.orbeon.com/Tabindex-in-repeating-region-help-td44715.html

Tabindex attributes are still copied to the HTML output (if there is no navindex attribute), but do not support AVTs.

This patch probably needs some cleanup and rework:
1. src/main/scala/org/orbeon/oxf/xforms/control/ControlExtensionAttributesSupport.scala
   => The method name addExtensionAttributesExceptClassAndAcceptForHandler doesn't reflect its behavior anymore. The extra check to exclude the navindex attribute was needed, because otherwise the control's span element received a navindex attribute. It needs to processed when sending an ajax response however (in addExtensionAttributesExceptClassAndAcceptForAjax)
2. src/resources-packaged/ops/javascript/orbeon/xforms/server/AjaxServer.js
   => Not sure if this is the way to change the tabindex attribute of a child. We couldn't find another example of an ajax response that set an attribute on a child HTML-element of the control. We also tried to specify the ID of the child-element in the server, but couldn't find an example of that either. This code also does the translation from navindex to tabindex in Javascript, which might not be desirable as well.
