### PR TITLE
Enable/disable initial focus via properties

### DIFF
--- a/src/resources-packaged/config/properties-form-runner.xml
+++ b/src/resources-packaged/config/properties-form-runner.xml
@@ -133,6 +133,7 @@
     <property as="xs:boolean" name="oxf.fr.detail.hide-top.*.*"                                 value="false"/>
     <property as="xs:boolean" name="oxf.fr.detail.hide-buttons-bar.*.*"                         value="false"/>
     <property as="xs:integer" name="oxf.fr.detail.autosave-delay.*.*"                           value="5000"/>
+    <property as="xs:boolean" name="oxf.fr.detail.initial-focus.enable.*.*"                     value="true"/>
 
     <!-- PDF template formatting -->
     <!-- NOTE: In the future we don't want those to apply to XHTML, but to an intermediate representation -->

--- a/src/resources-packaged/config/properties-form-runner.xml
+++ b/src/resources-packaged/config/properties-form-runner.xml
@@ -133,7 +133,7 @@
     <property as="xs:boolean" name="oxf.fr.detail.hide-top.*.*"                                 value="false"/>
     <property as="xs:boolean" name="oxf.fr.detail.hide-buttons-bar.*.*"                         value="false"/>
     <property as="xs:integer" name="oxf.fr.detail.autosave-delay.*.*"                           value="5000"/>
-    <property as="xs:boolean" name="oxf.fr.detail.initial-focus.enable.*.*"                     value="true"/>
+    <property as="xs:boolean" name="oxf.fr.detail.initial-focus.*.*"                            value="true"/>
 
     <!-- PDF template formatting -->
     <!-- NOTE: In the future we don't want those to apply to XHTML, but to an intermediate representation -->

--- a/src/resources/apps/fr/components/components.xsl
+++ b/src/resources/apps/fr/components/components.xsl
@@ -87,7 +87,7 @@
     <xsl:variable name="view-appearance" as="xs:string" select="(p:property(string-join(('oxf.fr.detail.view.appearance', $app, $form), '.')), 'full')[1]"/>
     <xsl:variable name="custom-model"    as="xs:anyURI?" select="p:property(string-join(('oxf.fr.detail.model.custom', $app, $form), '.'))"/>
 
-    <xsl:variable name="enable-initial-focus" select="p:property(string-join(('oxf.fr.detail.initial-focus.enable', $app, $form), '.'))" as="xs:boolean"/>
+    <xsl:variable name="enable-initial-focus" select="p:property(string-join(('oxf.fr.detail.initial-focus', $app, $form), '.'))" as="xs:boolean"/>
 
     <xsl:template match="/xh:html">
         <!-- Handle document language -->

--- a/src/resources/apps/fr/components/components.xsl
+++ b/src/resources/apps/fr/components/components.xsl
@@ -87,6 +87,8 @@
     <xsl:variable name="view-appearance" as="xs:string" select="(p:property(string-join(('oxf.fr.detail.view.appearance', $app, $form), '.')), 'full')[1]"/>
     <xsl:variable name="custom-model"    as="xs:anyURI?" select="p:property(string-join(('oxf.fr.detail.model.custom', $app, $form), '.'))"/>
 
+    <xsl:variable name="enable-initial-focus" select="p:property(string-join(('oxf.fr.detail.initial-focus.enable', $app, $form), '.'))" as="xs:boolean"/>
+
     <xsl:template match="/xh:html">
         <!-- Handle document language -->
         <xh:html lang="{{xxf:instance('fr-language-instance')}}"
@@ -296,7 +298,9 @@
                  Builder for example can open a dialog upon load. Another possible fix would be to fix setfocus to
                  understand that if a modal dialog is currently visible, setting focus to a control outside that dialog
                  should not have any effect. See https://github.com/orbeon/orbeon-forms/issues/2010  -->
-            <xf:setfocus ev:event="xforms-ready" control="fr-form-group" input-only="true"/>
+            <xsl:if test="$enable-initial-focus">
+                <xf:setfocus ev:event="xforms-ready" control="fr-form-group" input-only="true"/>
+            </xsl:if>
 
             <!-- Custom model content -->
             <xsl:apply-templates select="node()"/>


### PR DESCRIPTION
proposing a property to implement @ajw625's request in #1958 for a way to disable initial focus entirely