### PR TITLE
themed fr login pages using bootstrap and existing orbeon styles

### DIFF
--- a/src/resources/apps/fr/login-error.xhtml
+++ b/src/resources/apps/fr/login-error.xhtml
@@ -11,14 +11,73 @@
 
     The full text of the license is available at http://www.gnu.org/copyleft/lesser.html
 -->
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Form Runner Login Error</title>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <title>Error — Form Runner Login — Orbeon Forms</title>
+        <link rel="stylesheet" href="/apps/fr/style/bootstrap/css/bootstrap.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-bootstrap-override.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-orbeon.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-common.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-base.css"/>
     </head>
-    <body>
-        <h1>Login Error</h1>
-        <p>
-            You entered an invalid login. <a href="/fr/">Please try again</a>.
-        </p>
+    <body class="orbeon">
+
+        <div id="fr-view" class="fr-view container">
+            <nav class="navbar navbar-inverse">
+                <div class="navbar-inner">
+                    <div class="container">
+                        <a href="http://www.orbeon.com/"><img alt="" src="/apps/fr/style/orbeon-navbar-logo.png"/></a>
+                        <h1>Orbeon Forms</h1>
+                    </div>
+                </div>
+            </nav>
+
+            <div class="row">
+                <div class="span12">
+                    <div class="alert alert-danger">
+                        <h1>Login Error</h1>
+                        <p>
+                            You entered an invalid login. Please try again.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="span12">
+                    <div class="fr-border xbl-fr-section">
+                        <div class="fr-section-content">
+                            <h1>Form Runner Login</h1>
+                            <p>
+                                Please enter your login and password:
+                            </p>
+                            <form action="/j_security_check" method="post">
+                                <div class="control-group">
+                                    <label class="control-label" for="username">Login:</label>
+                                    <div class="controls">
+                                        <input type="text" id="username" name="j_username"/>
+                                    </div>
+                                </div>
+                                <div class="control-group">
+                                    <label class="control-label" for="password">Password:</label>
+                                    <div class="controls">
+                                        <input type="password" id="password" name="j_password"/>
+                                    </div>
+                                </div>
+                                <div class="control-group">
+                                    <div class="controls">
+                                        <button type="submit" class="btn">Login</button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </body>
 </html>

--- a/src/resources/apps/fr/login.xhtml
+++ b/src/resources/apps/fr/login.xhtml
@@ -11,29 +11,62 @@
 
     The full text of the license is available at http://www.gnu.org/copyleft/lesser.html
 -->
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Form Runner Login</title>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <title>Form Runner Login — Orbeon Forms</title>
+        <link rel="stylesheet" href="/apps/fr/style/bootstrap/css/bootstrap.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-bootstrap-override.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-orbeon.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-common.css"/>
+        <link rel="stylesheet" href="/apps/fr/style/form-runner-base.css"/>
     </head>
-    <body>
-        <p>
-            Please enter your login and password:
-        </p>
-        <form action="/j_security_check" method="post">
-            <table>
-                <tr>
-                    <td align="right">Login:</td>
-                    <td><input name="j_username"/></td>
-                </tr>
-                <tr>
-                    <td align="right">Password:</td>
-                    <td><input type="password" name="j_password"/></td>
-                </tr>
-                <tr>
-                    <td/><td>
-                    <input type="submit" value="Login"/></td>
-                </tr>
-            </table>
-        </form>
+    <body class="orbeon">
+
+        <div id="fr-view" class="fr-view container">
+            <nav class="navbar navbar-inverse">
+                <div class="navbar-inner">
+                    <div class="container">
+                        <a href="http://www.orbeon.com/"><img alt="" src="/apps/fr/style/orbeon-navbar-logo.png"/></a>
+                        <h1>Orbeon Forms</h1>
+                    </div>
+                </div>
+            </nav>
+
+            <div class="row">
+                <div class="span12">
+                    <div class="fr-border xbl-fr-section">
+                        <div class="fr-section-content">
+                            <h1>Form Runner Login</h1>
+                            <p>
+                                Please enter your login and password:
+                            </p>
+                            <form action="/j_security_check" method="post">
+                                <div class="control-group">
+                                    <label class="control-label" for="username">Login:</label>
+                                    <div class="controls">
+                                        <input type="text" id="username" name="j_username"/>
+                                    </div>
+                                </div>
+                                <div class="control-group">
+                                    <label class="control-label" for="password">Password:</label>
+                                    <div class="controls">
+                                        <input type="password" id="password" name="j_password"/>
+                                    </div>
+                                </div>
+                                <div class="control-group">
+                                    <div class="controls">
+                                        <button type="submit" class="btn">Login</button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </body>
 </html>


### PR DESCRIPTION
I hope this fulfills the requirements of #455. To match the existing theme, I've used existing styles.

My primary motive, however, is to fix something that I believe is a bug in the login behavior. When a user attempts to access a deep link into FR, they are redirected to the login page. If the user types incorrect credentials, they are presented with the error page and a link to the FR homepage. In order to  make a second login attempt they click the provided link. Now, upon successful login, they are not redirected to the initial URI (which I believe was their intent) but rather are taken to the FR homepage because the link caused them to request that page specifically. If the login error page includes the login form they are able to immediately make a second attempt and when eventually successful, they are redirected to the initial URI.
