### PR TITLE
Move XCV triggers into cells

### DIFF
--- a/src/resources/forms/orbeon/builder/form/form.xhtml
+++ b/src/resources/forms/orbeon/builder/form/form.xhtml
@@ -21,6 +21,7 @@
       xmlns:fr="http://orbeon.org/oxf/xml/form-runner"
       xmlns:fb="http://orbeon.org/oxf/xml/form-builder"
       xmlns:secure="java:org.orbeon.oxf.util.SecureUtils"
+      xmlns:toolboxOps="java:org.orbeon.oxf.fb.ToolboxOps"
       xmlns:fbf="java:org.orbeon.oxf.fb.FormBuilder">
     <xh:head>
         <!-- CSS -->
@@ -413,6 +414,27 @@
                                         <xf:label><xh:img src="/apps/fr/style/images/silk/bin.png" alt="{$fb-resources/delete-control-icon/label}" title="{$fb-resources/delete-control-icon/label}"/></xf:label>
                                         <xf:action ev:event="DOMActivate" type="xpath">
                                             fbf:deleteCellContent($td, true())
+                                        </xf:action>
+                                    </xf:trigger>
+                                    <!-- Cut control -->
+                                    <xf:trigger tabindex="-1" appearance="minimal" id="fb-cut-trigger">
+                                        <xf:label><xh:img src="/apps/fr/style/images/silk/cut.png" alt="{$form-resources/cut/label}" title="{$form-resources/cut/label}"/></xf:label>
+                                        <xf:action ev:event="DOMActivate" type="xpath">
+                                            toolboxOps:cutToClipboard($td)
+                                        </xf:action>
+                                    </xf:trigger>
+                                    <!-- Copy control -->
+                                    <xf:trigger tabindex="-1" appearance="minimal" id="fb-copy-trigger">
+                                        <xf:label><xh:img src="/forms/orbeon/builder/images/copy.png" alt="{$form-resources/copy/label}" title="{$form-resources/copy/label}"/></xf:label>
+                                        <xf:action ev:event="DOMActivate" type="xpath">
+                                            toolboxOps:copyToClipboard($td)
+                                        </xf:action>
+                                    </xf:trigger>
+                                    <!-- Paste control -->
+                                    <xf:trigger tabindex="-1" appearance="minimal" id="fb-paste-trigger">
+                                        <xf:label><xh:img src="/apps/fr/style/images/silk/paste_plain.png" alt="{$form-resources/paste/label}" title="{$form-resources/paste/label}"/></xf:label>
+                                        <xf:action ev:event="DOMActivate" type="xpath">
+                                            toolboxOps:pasteFromClipboard($td)
                                         </xf:action>
                                     </xf:trigger>
                                 </xh:span>

--- a/src/resources/forms/orbeon/builder/resources/cell/action-icons.coffee
+++ b/src/resources/forms/orbeon/builder/resources/cell/action-icons.coffee
@@ -43,6 +43,9 @@ relevanceRules = do ->
                                         else false                                                                                          # Catch all, which shouldn't happen
     'fb-shrink-trigger':            (gridTd) -> gridTd.rowSpan >= 2
     'fb-delete-trigger':            isNotEmpty
+    'fb-cut-trigger':               isNotEmpty
+    'fb-copy-trigger':              isNotEmpty
+    'fb-paste-trigger':             (gridTd) -> !isNotEmpty(gridTd)
     'fb-edit-details-trigger':      isNotEmpty
     'fb-edit-validation-trigger':   isNotEmpty
     'fb-edit-items-trigger':        (gridTd) -> isNotEmpty(gridTd) and $(gridTd).find('.fr-grid-content').hasClass('fb-itemset')


### PR DESCRIPTION
The current placement of of the Cut, Copy, and Paste triggers in the toolbox is very inconvenient for form editors requiring two large mouse movements for almost every operation. These actions would be much more convenient if the triggers could be moved directly into cells in the grid.

Know issues:
- Room inside the cells is tight. Cut and Copy can overflow the boundaries sometimes.
- Perhaps paste should be hidden when the clipboard is empty, but I don't know how to accomplish this.
