### PR TITLE
Add grid move up and down triggers

### DIFF
--- a/src/resources/forms/orbeon/builder/form/form.xhtml
+++ b/src/resources/forms/orbeon/builder/form/form.xhtml
@@ -556,6 +556,22 @@
                                     </xf:dispatch>
                                     <xf:action ev:event="fr-positive" type="xpath">fbf:deleteGridById(event('context'))</xf:action>
                                 </xf:trigger>
+                                <!-- Move up -->
+                                <xf:trigger tabindex="-1" appearance="minimal" id="grid-move-up-trigger" class="fb-grid-move-up-trigger">
+                                    <xf:label><xh:img width="16" height="16" src="/apps/fr/style/images/silk/arrow_up.png" alt="{$fb-resources/move-up-icon/label}" title="{$fb-resources/move-up-icon/label}"/></xf:label>
+                                    <!-- Move section up -->
+                                    <xf:action ev:event="DOMActivate" type="xpath">
+                                        fbf:moveSectionUp(fbf:containerById(event('grid-id')))
+                                    </xf:action>
+                                </xf:trigger>
+                                <!-- Move down -->
+                                <xf:trigger tabindex="-1" appearance="minimal" id="grid-move-down-trigger" class="fb-grid-move-down-trigger">
+                                    <xf:label><xh:img width="16" height="16" src="/apps/fr/style/images/silk/arrow_down.png" alt="{$fb-resources/move-down-icon/label}" title="{$fb-resources/move-down-icon/label}"/></xf:label>
+                                    <!-- Move section down -->
+                                    <xf:action ev:event="DOMActivate" type="xpath">
+                                        fbf:moveSectionDown(fbf:containerById(event('grid-id')))
+                                    </xf:action>
+                                </xf:trigger>
                                 <!-- Grid details -->
                                 <xf:trigger tabindex="-1" appearance="minimal" id="grid-details-trigger" class="fb-grid-details-trigger">
                                     <xf:label><xh:img src="/apps/fr/style/images/silk/cog.png" alt="{$fb-resources/grid-details-icon/label}" title="{$fb-resources/grid-details-icon/label}"/></xf:label>

--- a/src/resources/forms/orbeon/builder/resources/section-grid-repeat/grid-repeat-editor.coffee
+++ b/src/resources/forms/orbeon/builder/resources/section-grid-repeat/grid-repeat-editor.coffee
@@ -37,8 +37,10 @@ $ ->
         deleteIcon = $ '.fb-delete-grid-trigger'
         detailsIcon = $ '.fb-grid-details-trigger'
         detailsHeight = _.memoize -> f$.height detailsIcon
+        moveUpIcon = $ '.fb-grid-move-up-trigger'
+        moveDownIcon = $ '.fb-grid-move-down-trigger'
         Builder.currentContainerChanged gridsCache,
-            wasCurrent: -> _.each [deleteIcon, detailsIcon], (i) -> f$.hide i
+            wasCurrent: -> _.each [deleteIcon, detailsIcon, moveUpIcon, moveDownIcon], (i) -> f$.hide i
             becomesCurrent: (grid) ->
                 table = f$.find '.fr-grid', grid.el
                 if f$.is '.fb-can-delete-grid', table
@@ -54,6 +56,18 @@ $ ->
                         top: grid.head.offset.top + (grid.head.height - detailsHeight()) / 2 - Builder.scrollTop()
                         left: grid.offset.left
                     f$.offset offset, detailsIcon
+                if true
+                    f$.show moveUpIcon
+                    offset =
+                        top:  grid.offset.top - Builder.scrollTop()
+                        left: grid.offset.left - 40
+                    f$.offset offset, moveUpIcon
+                if true
+                    f$.show moveDownIcon
+                    offset =
+                        top:  grid.offset.top - Builder.scrollTop()
+                        left: grid.offset.left - 20
+                    f$.offset offset, moveDownIcon
 
     # Position icons do add/remove columns/rows
     do ->


### PR DESCRIPTION
Add to the discussion on #1845. This adds move up and down triggers to the left of the delete trigger. They work but the placement on the first grid in each section interferes with the section triggers.
