### PR TITLE
Add specific classes to Summary Page buttons

### DIFF
--- a/src/resources/apps/fr/summary/view.xhtml
+++ b/src/resources/apps/fr/summary/view.xhtml
@@ -881,7 +881,7 @@
 
                     <!-- Directly iterate over the tokenized property -->
                     <xf:repeat ref="xxf:split(xxf:property(string-join(('oxf.fr.summary.buttons', $app, $form), '.')))">
-                        <xh:span class="fr-button">
+                        <xh:span class="fr-button fr-{.}-button">
                             <!-- Home -->
                             <xf:group ref="if (. = 'home') then $enabled else ()">
                                 <xf:trigger ref=".">


### PR DESCRIPTION
Form detail buttons already have [specific classes](https://github.com/orbeon/orbeon-forms/blob/master/src/resources-packaged/xbl/orbeon/process-button/process-button.xbl#L42) this patch attempts to give the same treatment to the buttons at the bottom of the summary page.