### PR TITLE
add table-striped and table-hover classes to form summary page table

### DIFF
--- a/src/resources/apps/fr/summary/view.xhtml
+++ b/src/resources/apps/fr/summary/view.xhtml
@@ -603,7 +603,7 @@
                             <!-- One column for each detail -->
                             <xf:var name="positions" value="instance('fr-search-instance')/query[@name and @summary-field = 'true']/(count(preceding-sibling::query[@name]) + 1)"/>
 
-                            <xh:table class="table table-bordered table-condensed">
+                            <xh:table class="table table-bordered table-condensed table-striped table-hover">
                                 <!-- scrollable="horizontal" width="940px" -->
                                 <xh:thead>
                                     <xh:tr>


### PR DESCRIPTION
As seen on the FR home page, these subtle visual cues would be useful for the form summary page too. As noted in #2246 additional work may be necessary on the styles to enable table-striped.