### PR TITLE
Empty Fields not Clickable on Form Summary Page

### DIFF
--- a/src/resources/apps/fr/summary/view.xhtml
+++ b/src/resources/apps/fr/summary/view.xhtml
@@ -758,7 +758,7 @@
                                                                                     else ."/>
                                                             <xf:group ref=".[$edit-view != '']">
                                                                 <xh:a href="{$current-document-href}">
-                                                                    <xf:output value="$detail"/>
+                                                                    <xf:output value="if ($detail != '') then $detail else codepoints-to-string((160))"/>
                                                                 </xh:a>
                                                             </xf:group>
                                                             <xf:group ref=".[$edit-view = '']">


### PR DESCRIPTION
Casual user testing has shown that it is difficult for some users to know what action to take to edit saved forms when viewing the summary page. Empty fields in the summary table make this worse because they are not clickable.

This patch renders a space in empty fields to cause them to be clickable.

