### PR TITLE
FR Home: layout issue in table header

### DIFF
--- a/src/resources/apps/fr/home/home.xhtml
+++ b/src/resources/apps/fr/home/home.xhtml
@@ -733,15 +733,17 @@
                     <xf:group xxf:update="full">
                         <xh:table class="fr-forms-table table table-bordered table-condensed table-hover">
                             <xh:thead>
-                                <xh:tr>
-                                    <xf:group ref=".[$remote-successful]">
-                                        <xf:group ref=".[$any-has-admin-permission]">
-                                            <xh:th/>
-                                        </xf:group>
-                                        <xh:th colspan="{if ($any-has-admin-permission) then 2 else 1}"><xf:output value="$fr-resources/home/titles/local"/></xh:th>
-                                        <xh:th colspan="{if ($any-has-admin-permission) then 2 else 1}"><xf:output value="$fr-resources/home/titles/remote"/></xh:th>
-                                        <xh:th colspan="3"><xf:output value="$fr-resources/home/titles/form-identification"/></xh:th>
-                                    </xf:group>
+								<xf:group ref=".[$remote-successful]">
+									<xh:tr>
+										<xf:group ref=".[$any-has-admin-permission]">
+											<xh:th/>
+										</xf:group>
+										<xh:th colspan="{if ($any-has-admin-permission) then 2 else 1}"><xf:output value="$fr-resources/home/titles/local"/></xh:th>
+										<xh:th colspan="{if ($any-has-admin-permission) then 2 else 1}"><xf:output value="$fr-resources/home/titles/remote"/></xh:th>
+										<xh:th colspan="3"><xf:output value="$fr-resources/home/titles/form-identification"/></xh:th>
+									</xh:tr>
+								</xf:group>
+								<xh:tr>
                                     <xf:group ref=".[$any-has-admin-permission]">
                                         <xh:th/>
                                         <xh:th><xf:output value="$fr-resources/home/titles/status"/></xh:th>
@@ -962,6 +964,6 @@
             </xf:action>
 
         </xxf:dialog>
-        <!--<fr:xforms-inspector/>-->
+        <fr:xforms-inspector/>
     </xh:body>
 </xh:html>

--- a/src/resources/apps/fr/home/home.xhtml
+++ b/src/resources/apps/fr/home/home.xhtml
@@ -964,6 +964,6 @@
             </xf:action>
 
         </xxf:dialog>
-        <fr:xforms-inspector/>
+        <!--<fr:xforms-inspector/>-->
     </xh:body>
 </xh:html>


### PR DESCRIPTION
Issue occurs when FR is set up for a remote prod server: column headers are displayed all on one row due to missing `<tr>`: 
![image](https://cloud.githubusercontent.com/assets/506171/9609141/ed0a9758-5086-11e5-99b9-5a404be78bde.png)

After fix:
![image](https://cloud.githubusercontent.com/assets/506171/9612207/25d49aea-5099-11e5-9d62-79cfd3f7d5a4.png)

