### PR TITLE
Prevent namespace errors in the proxy portlet

### DIFF
--- a/descriptors/proxy-portlet/WEB-INF/liferay-portlet.xml
+++ b/descriptors/proxy-portlet/WEB-INF/liferay-portlet.xml
@@ -2,5 +2,6 @@
     <portlet>
         <portlet-name>orbeon-forms-proxy-portlet</portlet-name>
         <instanceable>true</instanceable>
+        <requires-namespaced-parameters>false</requires-namespaced-parameters>
     </portlet>
 </liferay-portlet-app>


### PR DESCRIPTION
Adding this line to liferay-portlet.xml is a temporary fix that prevents display issues and other errors. This is only required until the proxy-portlet is updated to support the namespacing that liferay wants.